### PR TITLE
UserのCRUD操作をリファクタ

### DIFF
--- a/src/main/kotlin/com/keyskey/ktknowledge/entities/User.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/entities/User.kt
@@ -4,17 +4,15 @@ import java.time.LocalDateTime
 
 interface UserDefinition {
     val name: String
-    val createdAt: LocalDateTime
-    val updatedAt: LocalDateTime
 }
 
 data class UserProperty(
     override val name: String,
-    override val createdAt: LocalDateTime,
-    override val updatedAt: LocalDateTime
 ): UserDefinition
 
 data class User(
     val id: Int,
     private val property: UserProperty,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime
 ): UserDefinition by property

--- a/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/mutations/UserMutation.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/mutations/UserMutation.kt
@@ -2,6 +2,7 @@ package com.keyskey.ktknowledge.handlers.graphql.mutations
 
 import com.expediagroup.graphql.generator.scalars.ID
 import com.expediagroup.graphql.server.operations.Mutation
+import com.keyskey.ktknowledge.entities.UserProperty
 import com.keyskey.ktknowledge.handlers.graphql.types.UserType
 import com.keyskey.ktknowledge.handlers.graphql.types.toUserType
 import com.keyskey.ktknowledge.handlers.graphql.utils.toID
@@ -11,25 +12,30 @@ import org.springframework.stereotype.Component
 
 @Component
 class UserMutation(private val userRepository: UserRepository): Mutation {
-    fun createUser(name: String): UserType? {
+    fun createUser(name: String): UserType {
         return userRepository
-            .create(name)
+            .create(UserProperty(name))
             .toUserType()
     }
 
-    fun updateUserName(id: ID, name: String): UserType? {
-        val user = id.toIntOrNull()?.let {
-            userRepository
-                .updateName(it, name)
-                ?.toUserType()
-        }
+    fun updateUser(id: ID, name: String): UserType? {
+        val intId = id.toIntOrNull()
+        intId ?: return null
 
-        return user
+        val userId = userRepository.update(intId, UserProperty(name))
+        userId ?: return null
+
+        return userRepository
+            .findById(userId)
+            ?.toUserType()
     }
 
     fun deleteUser(id: ID): ID? {
-        val deletedUserId = id.toIntOrNull()?.let { userRepository.delete(it) }
+        val intId = id.toIntOrNull()
+        intId ?: return null
 
-        return deletedUserId?.toID()
+        return userRepository
+            .delete(intId)
+            ?.toID()
     }
 }

--- a/src/main/kotlin/com/keyskey/ktknowledge/repositories/UserRepository.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/repositories/UserRepository.kt
@@ -21,7 +21,7 @@ class UserRepository(val database: Database) {
         checkNotNull(createdAt)
         checkNotNull(updatedAt)
 
-        return User(id, UserProperty(name, createdAt, updatedAt))
+        return User(id, UserProperty(name), createdAt, updatedAt)
     }
 
     fun findAll(): List<User> {
@@ -41,26 +41,26 @@ class UserRepository(val database: Database) {
             .singleOrNull()
     }
 
-    fun create(name: String): User {
-        val property = UserProperty(name, timestamp(), timestamp())
+    fun create(property: UserProperty): User {
+        val now = timestamp()
         val id = database.insertAndGenerateKey(Users) {
             set(it.name, property.name)
-            set(it.createdAt, property.createdAt)
-            set(it.updatedAt, property.updatedAt)
+            set(it.createdAt, now)
+            set(it.updatedAt, now)
         }.toString().toInt()
 
-        return User(id, property)
+        return User(id, property, now, now)
     }
 
-    fun updateName(id: Int, name: String): User? {
+    fun update(id: Int, property: UserProperty): Int? {
         val numRowsAffected = database.update(Users) {
-            set(it.name, name)
+            set(it.name, property.name)
             set(it.updatedAt, timestamp())
             where { it.id eq id }
         }
 
         return if (numRowsAffected > 0) {
-            findById(id)
+            id
         } else {
             null
         }


### PR DESCRIPTION
## やったこと
- データ更新操作は必ずpropertyクラスを経由するようにした
  - これで属性がめちゃくちゃ多いモデルが爆誕してもリポジトリの更新系メソッドの引数が増えることはなくなる 
  - 今後バリデーションライブラリを導入するときもpropertyクラス側にビジネス要件系のバリデーションを実装するだけでよくなるはず   
- propertyクラスにタイムスタンプ系の値を持たせていると更新系メソッドの呼び出し元で毎回タイムスタンプの値をセットさせないといけなくなり使い勝手が悪いので、propertyクラスにはタイムスタンプ系の値は持たせないようにした