### PR TITLE
タイムスタンプ系の値をGraphQLのレスポンスに含められるようにした

### DIFF
--- a/src/main/kotlin/com/keyskey/ktknowledge/KtknowledgeApplication.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/KtknowledgeApplication.kt
@@ -1,10 +1,15 @@
 package com.keyskey.ktknowledge
 
+import com.keyskey.ktknowledge.handlers.graphql.types.CustomSchemaGeneratorHooks
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
 
 @SpringBootApplication
-class KtknowledgeApplication
+class KtknowledgeApplication {
+	@Bean
+	fun customGraphQLSchemaGeneratorHooks() = CustomSchemaGeneratorHooks()
+}
 
 fun main(args: Array<String>) {
 	runApplication<KtknowledgeApplication>(*args)

--- a/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/CustomSchemaGeneratorHooks.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/CustomSchemaGeneratorHooks.kt
@@ -1,0 +1,48 @@
+package com.keyskey.ktknowledge.handlers.graphql.types
+
+import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import graphql.schema.*
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.jvm.internal.impl.resolve.constants.StringValue
+
+// see: https://github.com/ExpediaGroup/graphql-kotlin/blob/master/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/hooks/CustomSchemaGeneratorHooks.kt
+class CustomSchemaGeneratorHooks: SchemaGeneratorHooks {
+    // Register additional GraphQL scalar types.
+    override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier as? KClass<*>) {
+        LocalDateTime::class -> graphqlDateTimeType
+        else -> null
+    }
+}
+
+internal val graphqlDateTimeType: GraphQLScalarType = GraphQLScalarType.newScalar()
+    .name("DateTime")
+    .description("Custom scalar type representing java.time.LocalDateTime")
+    .coercing(LocalDateTimeCoercing)
+    .build()
+
+private object LocalDateTimeCoercing: Coercing<LocalDateTime, String> {
+    override fun serialize(dataFetcherResult: Any): String = runCatching {
+        dataFetcherResult.toString()
+    }.getOrElse {
+        throw CoercingSerializeException("Data fetcher result $dataFetcherResult cannot be serialized to a String")
+    }
+
+    override fun parseValue(input: Any): LocalDateTime = runCatching {
+        LocalDateTime.parse(serialize(input), DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    }.getOrElse {
+        throw CoercingParseValueException("Expected valid UUID but was $input")
+    }
+
+    override fun parseLiteral(input: Any): LocalDateTime {
+        val localDateTimeString = (input as? StringValue)?.value
+
+        return runCatching {
+            LocalDateTime.parse(localDateTimeString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        }.getOrElse {
+            throw CoercingParseLiteralException("Expected valid UUID literal but was $localDateTimeString")
+        }
+    }
+}

--- a/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/UserType.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/UserType.kt
@@ -2,10 +2,13 @@ package com.keyskey.ktknowledge.handlers.graphql.types
 
 import com.expediagroup.graphql.generator.scalars.ID
 import com.keyskey.ktknowledge.entities.User
+import java.time.LocalDateTime
 
-data class UserType (val id: ID, val name: String)
+data class UserType (val id: ID, val name: String, val createdAt: LocalDateTime, val updatedAt: LocalDateTime)
 
 fun User.toUserType(): UserType = UserType(
     id = ID(id.toString()),
-    name = name
+    name = name,
+    createdAt = createdAt,
+    updatedAt = updatedAt
 )


### PR DESCRIPTION
##やったこと
- LocalDateTime型の値をiso8601形式のStringに変換してGraphQLのレスポンスに含めることができるようにした
- UserQuery/MutationでcreatedAt/updatedAtの値を返却するようにした

## 調査メモ
1. まずはGraphQL Kotlin公式Docの https://opensource.expediagroup.com/graphql-kotlin/docs/schema-generator/writing-schemas/scalars#extended-scalars を見た。
> By default, graphql-kotlin only supports the primitive scalar types listed above. If you are looking to use common java types as scalars, you need to include the graphql-java-extended-scalars library and set up the hooks (see above), or write the logic yourself for how to resolve these custom scalars.
The most popular types that require extra configuration are: LocalDate, DateTime, Instant, ZonedDateTime, URL, UUID

タイムスタンプ系の値を使いたければgraphql-java-extended-scalarsを入れるか自前でJavaのタイムスタンプ系のクラスをプリミティブ型に変換するロジックを書く必要があるらしい。そのうちgraphql-java-extended-scalarsにない型も使いたくなるときが来るかもしれないので今回は後者の自前実装でやってみることにする。

2. 自前実装の例は1. の説明の真上に載っていたが、ドキュメントが古いのか、parseValue/parseLiteralの引数の型がドキュメントではnullableだがnullableだとダメだとコンパイラに怒られた。
3. 何が正しいのかよく分からんのでGraphQL-Kotlinが用意しているSpringBootでの[参考実装](https://github.com/ExpediaGroup/graphql-kotlin/tree/master/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring)を見ることにした。すると[CustomSchemaGeneratorHooksの最新実装例らしきもの](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/hooks/CustomSchemaGeneratorHooks.kt) があった。この例はUUID型を定義しているやつだが、真似してLocalDateTime版を実装してみた。そしたら見事に動いた 💯 

![image](https://user-images.githubusercontent.com/39644776/141642299-7b79c91b-0dd7-4078-b700-51b1bf9eb476.png)
