### PR TITLE
ユーザー作成時にメアドとパスワードを保存する

### DIFF
--- a/src/main/kotlin/com/keyskey/ktknowledge/entities/User.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/entities/User.kt
@@ -3,6 +3,7 @@ package com.keyskey.ktknowledge.entities
 import com.keyskey.ktknowledge.utils.throwOnFailure
 import com.keyskey.ktknowledge.utils.timestamp
 import org.valiktor.functions.hasSize
+import org.valiktor.functions.isEmail
 import org.valiktor.functions.isGreaterThanOrEqualTo
 import org.valiktor.validate
 import java.time.LocalDateTime
@@ -10,6 +11,8 @@ import java.time.LocalDateTime
 data class User(
     val id: Int,
     val name: String,
+    val email: String,
+    val password: String,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime
 ) {
@@ -18,14 +21,22 @@ data class User(
             validate(this) {
                 validate(User::id).isGreaterThanOrEqualTo(0)
                 validate(User::name).hasSize(min = 1, max = 20)
+                validate(User::email).isEmail()
             }
         }.throwOnFailure()
     }
 
     companion object {
-        fun build(id: Int = 0, name: String): User {
+        fun build(id: Int = 0, name: String, email: String, password: String): User {
             val now = timestamp()
-            return User(id, name, now, now)
+            return User(
+                id = id,
+                name = name,
+                email = email,
+                password = password,
+                createdAt = now,
+                updatedAt = now
+            )
         }
     }
 }

--- a/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/mutations/CreateUserMutation.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/mutations/CreateUserMutation.kt
@@ -8,9 +8,13 @@ import org.springframework.stereotype.Component
 
 @Component
 class CreateUserMutation(private val createUserCommand: CreateUserCommand): Mutation {
-    fun createUser(name: String): UserType {
+    fun createUser(name: String, email: String, password: String): UserType {
         val response = createUserCommand
-            .call(name)
+            .call(
+                name = name,
+                email = email,
+                password = password
+            )
             .toUserType()
 
         return response

--- a/src/main/kotlin/com/keyskey/ktknowledge/repositories/UserRepository.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/repositories/UserRepository.kt
@@ -11,15 +11,26 @@ class UserRepository(val database: Database) {
     private fun QueryRowSet.toUser(): User {
         val id = this[Users.id]
         val name = this[Users.name]
+        val email = this[Users.email]
+        val password = this[Users.password]
         val createdAt = this[Users.createdAt]
         val updatedAt = this[Users.updatedAt]
 
         checkNotNull(id)
         checkNotNull(name)
+        checkNotNull(email)
+        checkNotNull(password)
         checkNotNull(createdAt)
         checkNotNull(updatedAt)
 
-        return User(id, name, createdAt, updatedAt)
+        return User(
+            id = id,
+            name = name,
+            email = email,
+            password = password,
+            createdAt = createdAt,
+            updatedAt = updatedAt
+        )
     }
 
     fun findAll(): List<User> {
@@ -42,6 +53,8 @@ class UserRepository(val database: Database) {
     fun create(user: User): User {
         val id = database.insertAndGenerateKey(Users) {
             set(it.name, user.name)
+            set(it.email, user.email)
+            set(it.password, user.password)
             set(it.createdAt, user.createdAt)
             set(it.updatedAt, user.updatedAt)
         }.toString().toInt()

--- a/src/main/kotlin/com/keyskey/ktknowledge/repositories/database/Users.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/repositories/database/Users.kt
@@ -8,6 +8,8 @@ import org.ktorm.schema.varchar
 object Users: Table<Nothing>("users") {
     val id = int("id").primaryKey()
     val name = varchar("name")
+    val email = varchar("email")
+    val password = varchar("password")
     val createdAt = datetime("created_at")
     val updatedAt = datetime("updated_at")
 }

--- a/src/main/kotlin/com/keyskey/ktknowledge/usecases/commands/CreateUserCommand.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/usecases/commands/CreateUserCommand.kt
@@ -8,8 +8,12 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class CreateUserCommand(private val userRepository: UserRepository) {
     @Transactional
-    fun call(name: String): User {
-        val user = User.build(name = name)
+    fun call(name: String, email: String, password: String): User {
+        val user = User.build(
+            name = name,
+            email = email,
+            password = password
+        )
 
         return userRepository.create(user)
     }

--- a/src/main/resources/db/migration/V2__ADD_COLUMS_FOR_AUTH_TO_USERS.sql
+++ b/src/main/resources/db/migration/V2__ADD_COLUMS_FOR_AUTH_TO_USERS.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD (email varchar(255) not null, password varchar(60) not null);
+ALTER TABLE users ADD UNIQUE idx_id_email (id, email);


### PR DESCRIPTION
## やったこと
- usersテーブルにemail/passwordカラムを追加
- CreateUserMutation でemail/password を受け取るように変更

## Todo
- 平文で受け取ったPWをハッシュ化してDBに保存する
  - SpringSecurity の導入が必要だが割とめんどくさそうだったので一旦保留 