### PR TITLE
IDに `User:` プレフィックスを付けるようにした

### DIFF
--- a/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/mutations/DeleteUserMutation.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/mutations/DeleteUserMutation.kt
@@ -2,16 +2,19 @@ package com.keyskey.ktknowledge.handlers.graphql.mutations
 
 import com.expediagroup.graphql.generator.scalars.ID
 import com.expediagroup.graphql.server.operations.Mutation
-import com.keyskey.ktknowledge.handlers.graphql.utils.toID
+import com.keyskey.ktknowledge.handlers.graphql.types.UserType
+import com.keyskey.ktknowledge.handlers.graphql.types.toUserType
 import com.keyskey.ktknowledge.handlers.graphql.utils.toInt
 import com.keyskey.ktknowledge.usecases.commands.DeleteUserCommand
 import org.springframework.stereotype.Component
 
 @Component
 class DeleteUserMutation(private val deleteUserCommand: DeleteUserCommand): Mutation {
-    fun deleteUser(id: ID): ID {
+    fun deleteUser(id: ID): UserType {
         val intId = id.toInt()
-        val response = deleteUserCommand.call(intId).toID()
+        val response = deleteUserCommand
+            .call(intId)
+            .toUserType()
 
         return response
     }

--- a/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/UserType.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/UserType.kt
@@ -1,13 +1,18 @@
 package com.keyskey.ktknowledge.handlers.graphql.types
 
+import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.scalars.ID
 import com.keyskey.ktknowledge.entities.User
+import com.keyskey.ktknowledge.handlers.graphql.utils.toID
 import java.time.LocalDateTime
 
+const val userTypeGraphQLName = "User"
+
+@GraphQLName(userTypeGraphQLName)
 data class UserType (val id: ID, val name: String, val createdAt: LocalDateTime, val updatedAt: LocalDateTime)
 
 fun User.toUserType(): UserType = UserType(
-    id = ID(id.toString()),
+    id = id.toID(userTypeGraphQLName),
     name = name,
     createdAt = createdAt,
     updatedAt = updatedAt

--- a/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/utils/ScalarUtil.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/utils/ScalarUtil.kt
@@ -1,7 +1,18 @@
 package com.keyskey.ktknowledge.handlers.graphql.utils
 
 import com.expediagroup.graphql.generator.scalars.ID
+import graphql.relay.Relay
 
-fun ID.toInt(): Int = this.toString().toInt()
+fun ID.toInt(): Int {
+    // IDは `User:1` のような値がBase64エンコーディングされたものであることを期待している
+    // Relay#fromGlobalId はこのIDをデコードした上で`:`でsplitし、type: "User と id: "1" を持つResolvedGlobalIdのインスタンスを返してくれる
+    val globalId: Relay.ResolvedGlobalId = Relay().fromGlobalId(this.toString())
 
-fun Int.toID(): ID = ID(this.toString())
+    return globalId.id.trim().toInt()
+}
+
+fun Int.toID(type: String): ID {
+    val globalId: String = Relay().toGlobalId(type, this.toString())
+
+    return ID(globalId)
+}

--- a/src/main/kotlin/com/keyskey/ktknowledge/usecases/commands/DeleteUserCommand.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/usecases/commands/DeleteUserCommand.kt
@@ -1,5 +1,6 @@
 package com.keyskey.ktknowledge.usecases.commands
 
+import com.keyskey.ktknowledge.entities.User
 import com.keyskey.ktknowledge.repositories.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -7,9 +8,11 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class DeleteUserCommand(private val userRepository: UserRepository) {
     @Transactional
-    fun call(id: Int): Int {
-        userRepository.delete(id)
+    fun call(id: Int): User {
+        val user = userRepository.findById(id)
+        checkNotNull(user)
+        userRepository.delete(user.id)
 
-        return id
+        return user
     }
 }


### PR DESCRIPTION
## やったこと
- UserType を スキーマ上では User と呼ぶことに変えた
- UserのIDはこれまでデータベース上のプライマリキーと同じシーケンスを文字列にした値だったが、 Relay specificationに従い `User:1` のように type名を頭に付けた文字列をBase64エンコーディングした値にしてレスポンスに含めるように変えた

## 調査メモ
実装の参考にしたのは GraphQL-Javaのサンプルコード: https://github.com/graphql-java/todomvc-relay-java/blob/master/src/main/java/todomvc/TodoSchema.java
