### PR TITLE
UserRepositoryを試しにEntity APIで実装してみたがダメだった件

### DIFF
--- a/src/main/kotlin/com/keyskey/ktknowledge/infrastructure/database/Users.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/infrastructure/database/Users.kt
@@ -1,15 +1,16 @@
 package com.keyskey.ktknowledge.infrastructure.database
 
+import com.keyskey.ktknowledge.infrastructure.repositories.UserDao
 import org.ktorm.schema.Table
 import org.ktorm.schema.datetime
 import org.ktorm.schema.int
 import org.ktorm.schema.varchar
 
-object Users: Table<Nothing>("users") {
-    val id = int("id").primaryKey()
-    val name = varchar("name")
-    val email = varchar("email")
-    val password = varchar("password")
-    val createdAt = datetime("created_at")
-    val updatedAt = datetime("updated_at")
+object Users: Table<UserDao>("users") {
+    val id = int("id").primaryKey().bindTo { it.id }
+    val name = varchar("name").bindTo { it.name }
+    val email = varchar("email").bindTo { it.email }
+    val password = varchar("password").bindTo { it.password }
+    val createdAt = datetime("created_at").bindTo { it.createdAt }
+    val updatedAt = datetime("updated_at").bindTo { it.updatedAt }
 }

--- a/src/main/kotlin/com/keyskey/ktknowledge/infrastructure/repositories/UsersRepositoryImpl.kt.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/infrastructure/repositories/UsersRepositoryImpl.kt.kt
@@ -5,36 +5,49 @@ import com.keyskey.ktknowledge.entities.UsersRepository
 import com.keyskey.ktknowledge.infrastructure.database.Users
 import org.ktorm.database.Database
 import org.ktorm.dsl.*
+import org.ktorm.entity.*
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+interface UserDao : Entity<UserDao> {
+    companion object : Entity.Factory<UserDao>()
+
+    val id: Int
+    var name: String
+    var email: String
+    var password: String
+    var createdAt: LocalDateTime
+    var updatedAt: LocalDateTime
+}
 
 @Repository
 class UsersRepositoryImpl(val database: Database): UsersRepository {
+    // insert時に生成されたidを取得する手段がない
     override fun create(user: User): User {
-        val id = database.insertAndGenerateKey(Users) {
-            set(it.name, user.name)
-            set(it.email, user.email)
-            set(it.password, user.password)
-            set(it.createdAt, user.createdAt)
-            set(it.updatedAt, user.updatedAt)
-        }.toString().toInt()
+        val userDao = buildDao(user)
+        users().add(userDao)
 
-        return user.copy(id = id)
+        return user
     }
 
     override fun update(user: User) {
-        database.update(Users) {
-            set(it.name, user.name)
-            set(it.email, user.email)
-            set(it.password, user.password)
-            set(it.createdAt, user.createdAt)
-            set(it.updatedAt, user.updatedAt)
-            where { it.id eq user.id }
-        }
+        val userDao = buildDao(user)
+        users().update(userDao)
     }
 
     override fun delete(id: Int) {
-        database.delete(Users) {
-            it.id eq id
+        users().removeIf { it.id eq id }
+    }
+
+    private fun buildDao(user: User): UserDao {
+        return UserDao {
+            name = user.name
+            email = user.email
+            password = user.password
+            createdAt = user.createdAt
+            updatedAt = user.updatedAt
         }
     }
+
+    private fun users() = database.sequenceOf(Users)
 }


### PR DESCRIPTION
## やったこと
- UserRepositoryの各メソッドをEntity APIを使って実装することで幾分ラクできないか検証してみた
- 結果、updateとdeleteはSQL DSLと同じロジックをより少ない行数で再現できた(その分設定を色々追加する手間もかかっている)が、createはダメだった。SQL DSLでいうところのinsertAndGenerateKeyメソッドみたいなものが用意されていないので、create時に生成されるIDを取得する手段がない。