### PR TITLE
タイムスタンプ系の値の変換にgraphql-java-extended-scalarsを使う

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 	implementation("com.expediagroup", "graphql-kotlin-spring-server", "5.1.0")
 	implementation("org.springframework.boot:spring-boot-starter:2.5.5")
 	implementation("org.valiktor:valiktor-spring-boot-starter:0.12.0")
+	implementation("com.graphql-java:graphql-java-extended-scalars:17.0")
 	developmentOnly("org.springframework.boot:spring-boot-devtools:2.5.5")
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:2.5.5")
 	testImplementation("org.springframework.boot:spring-boot-starter-test:2.5.5")

--- a/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/CustomSchemaGeneratorHooks.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/CustomSchemaGeneratorHooks.kt
@@ -1,48 +1,18 @@
 package com.keyskey.ktknowledge.handlers.graphql.types
 
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
-import graphql.schema.*
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import graphql.scalars.ExtendedScalars
+import graphql.schema.GraphQLType
+import java.time.ZonedDateTime
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
-import kotlin.reflect.jvm.internal.impl.resolve.constants.StringValue
 
 // see: https://github.com/ExpediaGroup/graphql-kotlin/blob/master/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/hooks/CustomSchemaGeneratorHooks.kt
-class CustomSchemaGeneratorHooks: SchemaGeneratorHooks {
+class CustomSchemaGeneratorHooks : SchemaGeneratorHooks {
     // Register additional GraphQL scalar types.
     override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier as? KClass<*>) {
-        LocalDateTime::class -> graphqlDateTimeType
+        // see: https://github.com/graphql-java/graphql-java-extended-scalars/blob/master/src/main/java/graphql/scalars/ExtendedScalars.java
+        ZonedDateTime::class -> ExtendedScalars.DateTime
         else -> null
-    }
-}
-
-internal val graphqlDateTimeType: GraphQLScalarType = GraphQLScalarType.newScalar()
-    .name("DateTime")
-    .description("Custom scalar type representing java.time.LocalDateTime")
-    .coercing(LocalDateTimeCoercing)
-    .build()
-
-private object LocalDateTimeCoercing: Coercing<LocalDateTime, String> {
-    override fun serialize(dataFetcherResult: Any): String = runCatching {
-        dataFetcherResult.toString()
-    }.getOrElse {
-        throw CoercingSerializeException("Data fetcher result $dataFetcherResult cannot be serialized to a String")
-    }
-
-    override fun parseValue(input: Any): LocalDateTime = runCatching {
-        LocalDateTime.parse(serialize(input), DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-    }.getOrElse {
-        throw CoercingParseValueException("Expected valid UUID but was $input")
-    }
-
-    override fun parseLiteral(input: Any): LocalDateTime {
-        val localDateTimeString = (input as? StringValue)?.value
-
-        return runCatching {
-            LocalDateTime.parse(localDateTimeString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-        }.getOrElse {
-            throw CoercingParseLiteralException("Expected valid UUID literal but was $localDateTimeString")
-        }
     }
 }

--- a/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/UserType.kt
+++ b/src/main/kotlin/com/keyskey/ktknowledge/handlers/graphql/types/UserType.kt
@@ -4,7 +4,8 @@ import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.scalars.ID
 import com.keyskey.ktknowledge.entities.User
 import com.keyskey.ktknowledge.handlers.graphql.utils.toID
-import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 const val userTypeGraphQLName = "User"
 
@@ -12,13 +13,13 @@ const val userTypeGraphQLName = "User"
 data class UserType(
     val id: ID,
     val name: String,
-    val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime)
+    val createdAt: ZonedDateTime,
+    val updatedAt: ZonedDateTime)
 {
     constructor(user: User) : this(
         user.id.toID(userTypeGraphQLName),
         user.name,
-        user.createdAt,
-        user.updatedAt
+        ZonedDateTime.of(user.createdAt, ZoneId.systemDefault()),
+        ZonedDateTime.of(user.updatedAt, ZoneId.systemDefault())
     )
 }


### PR DESCRIPTION
## 背景
- これまで、タイムスタンプ系の値を持つDBのレコードはEntityにマッピングするとLocalDateTime型のフィールドを持つように定義されていたので、GraphQLのTypeとしてもLocalDateTime型をISO8601形式の文字列に変換することで取り回していた。これを実現するためにGraphQL Kotlinの設定を拡張してカスタムスカラー型を定義していた。
- しかし日付型やURLやLocaleといった頻出の型の取り回しのために毎回拡張コードを書くのはちと面倒だった
 
## やったこと
- graphql-java-extended-scalarsを導入することで、どの辺りの定番の型を変換するロジックを書かなくて良いようにした。型変換の設定を書かなくて良くなった代わりにgraphql-java-extended-scalarsはLocalDateTime型をサポートしていないので、レスポンスを生成するときにLocalDateTime ⇔ ZonedDateTime のちょっとした変換をかます必要が出てきたけどまあ許容範囲と捉えたい

## 参考
- https://opensource.expediagroup.com/graphql-kotlin/docs/schema-generator/writing-schemas/scalars#extended-scalars
- https://github.com/graphql-java/graphql-java-extended-scalars#datetime-scalars
- https://github.com/graphql-java/graphql-java-extended-scalars/blob/master/src/main/java/graphql/scalars/datetime/DateTimeScalar.java 